### PR TITLE
Only create mapping if available

### DIFF
--- a/plugin/characterize.vim
+++ b/plugin/characterize.vim
@@ -39,7 +39,7 @@ function! s:info(char) abort
 endfunction
 
 nnoremap <silent><script> <Plug>(characterize) :<C-U>echo <SID>info(matchstr(getline('.')[col('.')-1:-1],'.'))<CR>
-if !hasmapto('<Plug>(characterize)', 'n')
+if !hasmapto('<Plug>(characterize)', 'n') && mapcheck('ga', 'n') ==# ''
   nmap ga <Plug>(characterize)
 endif
 


### PR DESCRIPTION
Check for the existence of an existing `ga` map before clobbering.

This allows one to, for example, map `ga` to something in their `vimrc` and still create a `<Plug>` mapping in `.vim/after/plugin/characterize.vim`:
```vim
nmap gA <Plug>(characterize)
```