### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,12 +11,13 @@ additions:
 
 ## Installation
 
-If you don't have a preferred installation method, I recommend
-installing [pathogen.vim](https://github.com/tpope/vim-pathogen), and
-then simply copy and paste:
+Install using your favorite package manager, or use Vim's built-in package
+support:
 
-    cd ~/.vim/bundle
-    git clone git://github.com/tpope/vim-characterize.git
+    mkdir -p ~/.vim/pack/tpope/start
+    cd ~/.vim/pack/tpope/start
+    git clone https://tpope.io/vim/characterize
+    vim -u NONE -c "helptags characterize/doc" -c q
 
 ## Contributing
 


### PR DESCRIPTION
GitHub stopped supporting git:// URLs some time ago.

Dunno if this should be updated to suggest cloning under ~/.vim/pack/tpope/start instead.